### PR TITLE
update zstandard dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     ],
     python_requires='>=2.7',
     install_requires=[
-        'zstandard==0.11.0',
+        'zstandard==0.22.0',
     ],
     extras_require={
         # eg:


### PR DESCRIPTION
The old zstandard dependency was having issues compiling. It looks like the new one is working fine.